### PR TITLE
More consistent and explicit “meta name” for style names

### DIFF
--- a/doc/keytheorems-doc.tex
+++ b/doc/keytheorems-doc.tex
@@ -917,7 +917,7 @@ Every finitely generated projective module over a polynomial ring is free.
 \label{thmstyles}
 
 \begin{docCommand}{newkeytheoremstyle}
-  {\marg{name}\marg{options}}
+  {\marg{style name}\marg{options}}
 This is \pkg{keytheorems}' version of \pkg{thmtools}' \cs{declaretheoremstyle}.
 Since it makes little sense to define a style with no keys, we've made the \meta{options} argument mandatory.
 The defined style can be used with either the \refKey{style} key or the traditional \cs{theoremstyle}.
@@ -925,7 +925,7 @@ Note that unlike \pkg{amsthm}'s \cs{newtheoremstyle}, this command will error if
 \end{docCommand}
 
 \begin{docCommands}[
-  doc parameter=\marg{env name}\marg{options}
+  doc parameter=\marg{style name}\marg{options}
   ]
   {
     {doc name = renewkeytheoremstyle},


### PR DESCRIPTION
We currently have:
```latex
\newkeytheoremstyle{⟨name⟩}{⟨options⟩}
[...]
\renewkeytheoremstyle{⟨env name⟩}{⟨options⟩}
\providekeytheoremstyle{⟨env name⟩}{⟨options⟩}
\declarekeytheoremstyle{⟨env name⟩}{⟨options⟩}
```
which is inconsistent and `⟨name⟩` is not meaningful. This PR changes this into:
```latex
\newkeytheoremstyle{⟨style name⟩}{⟨options⟩}
[...]
\renewkeytheoremstyle{⟨style name⟩}{⟨options⟩}
\providekeytheoremstyle{⟨style name⟩}{⟨options⟩}
\declarekeytheoremstyle{⟨style name⟩}{⟨options⟩}
```

