### PR TITLE
Add Hungarian translations

### DIFF
--- a/tex/keytheorems.sty
+++ b/tex/keytheorems.sty
@@ -3075,6 +3075,16 @@
         \ProvideTranslation { German }     { keythms_theorem }      { Theorem }
         \ProvideTranslation { Greek }      { keythms_listof_title } { Κατάλογος~θεωρημάτων }
         \ProvideTranslation { Hungarian }  { keythms_listof_title } { A~tételek~listája }
+        \ProvideTranslation { Hungarian }  { keythms_continues }    { folytatás~innen:\, }
+        \ProvideTranslation { Hungarian }  { keythms_axiom }        { axióma }
+        \ProvideTranslation { Hungarian }  { keythms_conjecture }   { sejtés }
+        \ProvideTranslation { Hungarian }  { keythms_corollary }    { következmény }
+        \ProvideTranslation { Hungarian }  { keythms_definition }   { definíció }
+        \ProvideTranslation { Hungarian }  { keythms_example }      { példa }
+        \ProvideTranslation { Hungarian }  { keythms_lemma }        { lemma }
+        \ProvideTranslation { Hungarian }  { keythms_proposition }  { állítás }
+        \ProvideTranslation { Hungarian }  { keythms_remark }       { megjegyzés }
+        \ProvideTranslation { Hungarian }  { keythms_theorem }      { tétel }
         \ProvideTranslation { Icelandic }  { keythms_listof_title } { Listi~yfir~setningar }
         \ProvideTranslation { Indonesian } { keythms_listof_title } { Daftar~Teorema }
         \ProvideTranslation { Italian }    { keythms_listof_title } { Elenco~dei~teoremi }


### PR DESCRIPTION
Translations are intentionally kept lowercase since in Hungarian typography the numbering precedes the text.
(E.g., "1.1. tétel.")


The additions are the following:
```tex
        \ProvideTranslation { Hungarian }  { keythms_continues }    { folytatás~innen:\, }
        \ProvideTranslation { Hungarian }  { keythms_axiom }        { axióma }
        \ProvideTranslation { Hungarian }  { keythms_conjecture }   { sejtés }
        \ProvideTranslation { Hungarian }  { keythms_corollary }    { következmény }
        \ProvideTranslation { Hungarian }  { keythms_definition }   { definíció }
        \ProvideTranslation { Hungarian }  { keythms_example }      { példa }
        \ProvideTranslation { Hungarian }  { keythms_lemma }        { lemma }
        \ProvideTranslation { Hungarian }  { keythms_proposition }  { állítás }
        \ProvideTranslation { Hungarian }  { keythms_remark }       { megjegyzés }
        \ProvideTranslation { Hungarian }  { keythms_theorem }      { tétel }
```

The only translation which could be more natural is for `keythms_continues`  ("continuing from page X"). The correct choice would be "folytatás a(z) X. oldalról", but this is grammar dependent and the number would have to appear in the middle. For this reason I chose to go with "folytatás innen: X" ("continuation from here:"), which I think is better than not having a  translation at all.